### PR TITLE
Adding xslt parameter in kafka message

### DIFF
--- a/lib/jnpr/junos/octerm.py
+++ b/lib/jnpr/junos/octerm.py
@@ -60,7 +60,8 @@ class OCTerm(_Connection):
         self._producer = producer
         self._id = id
         self._async_consumer = kvargs.get("async_consumer", True)
-
+        self._xslt = kvargs.get("xslt", "") 
+        
         if kvargs.get("result"):
             logger.info('Creating oc-term class for consumer')
             self.kafka_result = kvargs["result"]
@@ -213,8 +214,15 @@ class OCTerm(_Connection):
             "params": rpc_cmd,
             "netconfCommand": rpc_cmd
         }
+        
+        if self._xslt != "":
+            kafka_cmd["params"] = {
+                "netconfCommand" : rpc_cmd,
+                "filterXSLT": self._xslt
+            }
+        
         result = ""
-
+        
         # consumer = KafkaConsumer(
         #     self._response_topic,
         #     bootstrap_servers=self._kafka_brokers.split(","),


### PR DESCRIPTION
Supporting processing of XSLT content if it is present in the tablefiles.
A sample tablefile with XSLT content:
```
---
intfaceStats:
  rpc: get-interface-information
  args:
    extensive: True
  item: physical-interface
  key: name
  view: intfStatsView

intfStatsView:
  groups:
    ts: traffic-statistics
    oe: output-error-list
    ie: input-error-list
  fields:
    interface_name: name
    oper_status: oper-status
    admin_status: admin-status
    speed: speed
  fields_ts:
    input_bytes: {input-bytes: int}
    output_bytes: {output-bytes: int}
  fields_oe:
    carrier_transitions: {carrier-transitions: int}
    output_errors: {output-errors: int}
  fields_ie:
    input_errors: {input-errors: int}

xslt: "<xsl:stylesheet version=\"1.0\"
 xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\"
 xmlns:ns=\"some:ns\">
 <xsl:output omit-xml-declaration=\"yes\" indent=\"yes\"/>
 <xsl:strip-space elements=\"*\"/>
 <ns:WhiteList>
      <name>name</name>
      <name>admin-status</name>
      <name>fec_ccw_count</name>
      <name>fec_nccw_count</name>
      <name>framing-errors</name>
      <name>input-crc-errors</name>
      <name>output-crc-errors</name>
 </ns:WhiteList>
 <ns:blacklist>
      <item>Mexico</item>
      <name>logical-interface</name>
 </ns:blacklist>
 <xsl:template match=\"node()|@*\">
      <xsl:copy>
             <xsl:apply-templates select=\"node()|@*\"/>
      </xsl:copy>
 </xsl:template>
 <xsl:template match=
  \"*[not(descendant-or-self::*[name()=document('')/*/ns:WhiteList/*]) or (self::*[name()=document('')/*/ns:blacklist/*])]\"/>
 </xsl:stylesheet>"

```

If xslt is present, then the kafka message on oc-cmd topic would look like:
```
{
  "op": "OC_COMMAND",
  "command": "netconf-rpc",
  "requestID": "pyezsched::2c6bf5cdd100:83b2e42c-2fef-44fc-9e09-b3ab7e086d98:8064f2ee-ac93-469b-b0be-1c3c98670a92:8064f2ee-ac93-469b-b0be-1c3c98670a92:intfaceStats:interface-error-details.yml:tand.healthbot:30001:1676537344.865376",
  "resource": "2c-6b-f5-cd-d1-00",
  "id": "2c-6b-f5-cd-d1-00",
  "params": {
    "netconfCommand": "<get-interface-information><extensive/></get-interface-information>",
    "filterXSLT": "<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" xmlns:ns=\"some:ns\"> <xsl:output omit-xml-declaration=\"yes\" indent=\"yes\"/> <xsl:strip-space elements=\"*\"/> <ns:WhiteList> <name>name</name> <name>admin-status</name> <name>fec_ccw_count</name> <name>fec_nccw_count</name> <name>framing-errors</name> <name>input-crc-errors</name> <name>output-crc-errors</name> </ns:WhiteList> <ns:blacklist> <item>Mexico</item> <name>logical-interface</name> </ns:blacklist> <xsl:template match=\"node()|@*\"> <xsl:copy> <xsl:apply-templates select=\"node()|@*\"/> </xsl:copy> </xsl:template> <xsl:template match= \"*[not(descendant-or-self::*[name()=document('')/*/ns:WhiteList/*]) or (self::*[name()=document('')/*/ns:blacklist/*])]\"/> </xsl:stylesheet>"
  },
  "netconfCommand": "<get-interface-information><extensive/></get-interface-information>"
}

```
else default to the regular below format:
```
{
    "op": "OC_COMMAND",
    "command": "netconf-rpc",
    "requestID": "pyezsched::f4bfa8a5424c:970872bc-4ba6-4fa0-b268-fc57c5274d98:1287fe98-d970-48cf-8941-b2b3088194b5:1287fe98-d970-48cf-8941-b2b3088194b5:intfaceStats:interface-error-details.yml:tand.healthbot:30001:1675132355.7172227",
    "resource": "f4-bf-a8-a5-42-4c",
    "id": "f4-bf-a8-a5-42-4c",
    "params": "<get-interface-information><extensive/></get-interface-information>",
    "netconfCommand": "<get-interface-information><extensive/></get-interface-information>"
}
```
