### PR TITLE
Skip SSH connection when RPC is timed out

### DIFF
--- a/lib/jnpr/junos/factory/cmdtable.py
+++ b/lib/jnpr/junos/factory/cmdtable.py
@@ -10,7 +10,7 @@ from lxml import etree
 import json
 
 # local
-from jnpr.junos.exception import RpcError
+from jnpr.junos.exception import RpcError, RpcTimeoutError
 from jnpr.junos.utils.start_shell import StartShell
 from jnpr.junos.factory.state_machine import StateMachine
 from jnpr.junos.factory.to_json import TableJSONEncoder
@@ -148,7 +148,11 @@ class CMDTable(object):
                         # </rpc-reply>
                         # hence need to do cleanup
                         self.data = self.data.replace("GOT: ", "")
-                except RpcError:
+                except RpcTimeoutError as exc:
+                    logger.error(f"RPC timedout, cmd: {self.GET_CMD}, target: {self.TARGET}, details: {exc}")
+                    raise exc
+                except RpcError as exc:
+                    logger.error(f"RPC errored falling to SSH, cmd: {self.GET_CMD}, target: {self.TARGET}, details: {exc}")
                     with StartShell(self.D) as ss:
                         ret = ss.run(
                             'cprod -A %s -c "%s"' % (self.TARGET, self.GET_CMD)


### PR DESCRIPTION
Current Design:

The RPC Command executions with `target` field present needs to be executed on `PFE`.  The commands that needs to be executed on PFE is executed through `request_pfe_execute`. Currently Pyez when executing such RPC through `request_pfe_execute` has a fallback mechanism when errored out. This fallback mechanism opens an ephemeral SSH session and executes the same command through `cprod`. 


Issue: 
In certain scenarios, The fallback mechanism of opening ephemeral SSH session is opening too many SSH sessions when there are too many commands that needs to be executed on the PFE and the device is not able to service all the incoming requests. This is causing of denial of SSH service on the device side

Fix: 

From the observations in the problematic setup,  most of the time RPC Is failing due to timeout as the device is busy and Pyez still goes ahead and opens SSH which is turns causes to open mutliple SSH sessions. So to fix this, the current change will skip opening of SSH session when RPC is timedout